### PR TITLE
Fix ExtractAndConvertToRGB565

### DIFF
--- a/src/ScreenCapture.cpp
+++ b/src/ScreenCapture.cpp
@@ -68,7 +68,7 @@ namespace Screen_Capture {
         auto imgsrc = StartSrc(img);
         auto imgdist = dst;
         for (auto h = 0; h < Height(img); h++) {
-            for (auto w = 0; w < Width(img); w++)
+            for (auto w = 0; w < Width(img); w++) {
                 unsigned char r = (*(imgsrc + 2)) & 0xF8;
                 unsigned char g = (*(imgsrc + 1)) & 0xFC;
                 unsigned char b = (*imgsrc) & 0xF8;

--- a/src/ScreenCapture.cpp
+++ b/src/ScreenCapture.cpp
@@ -68,10 +68,13 @@ namespace Screen_Capture {
         auto imgsrc = StartSrc(img);
         auto imgdist = dst;
         for (auto h = 0; h < Height(img); h++) {
-            for (auto w = 0; w < Width(img); w++) {
-                int short rgb = (*(imgsrc + 2) << 11) | (*(imgsrc + 1) << 5) | *(imgsrc);
+            for (auto w = 0; w < Width(img); w++)
+                unsigned char r = (*(imgsrc + 2)) & 0xF8;
+                unsigned char g = (*(imgsrc + 1)) & 0xFC;
+                unsigned char b = (*imgsrc) & 0xF8;
+                int short rgb = (r << 8) | (g << 3) | (b >> 3);
                 *imgdist++ = static_cast<unsigned char>(rgb);
-                *imgdist++ = static_cast<unsigned char>(rgb << 8);
+                *imgdist++ = static_cast<unsigned char>(rgb >> 8);
                 imgsrc += img.Pixelstride;
             }
             imgsrc += RowPadding(img);


### PR DESCRIPTION
While trying things out I had a problem with the output from the
ExtractAndConvertToRGB565 function.

The current version doesn't seam to do any bit width reduction and
the shifting looked wrong. I've reimplemented and it now works
with the existing code I already had.

Should fix #36 