### PR TITLE
fix Win32 issue: disconnected monitors on would cause vector bounds exception

### DIFF
--- a/src/windows/GetMonitors.cpp
+++ b/src/windows/GetMonitors.cpp
@@ -42,7 +42,7 @@ namespace Screen_Capture {
                     break;
                 }
                 ret.push_back(
-                    CreateMonitor(i, i, devMode.dmPelsHeight, devMode.dmPelsWidth, devMode.dmPosition.x, devMode.dmPosition.y, name, scale));
+                    CreateMonitor(static_cast<int>(ret.size()), i, devMode.dmPelsHeight, devMode.dmPelsWidth, devMode.dmPosition.x, devMode.dmPosition.y, name, scale));
             }
         }
         return ret;


### PR DESCRIPTION
I have three monitors, but monitors 0 and 2 are disconnected. This would cause a vector bounds exception in `isMonitorInsideBounds`:

```auto &realmonitor = monitors[Index(monitor)];```

as `monitors.size() == 1` but `Index(monitor) == 1`