### PR TITLE
fix two DXGI issues

### DIFF
--- a/include/SCCommon.h
+++ b/include/SCCommon.h
@@ -43,6 +43,7 @@ namespace Screen_Capture {
     enum DUPL_RETURN { DUPL_RETURN_SUCCESS = 0, DUPL_RETURN_ERROR_EXPECTED = 1, DUPL_RETURN_ERROR_UNEXPECTED = 2 };
     const int PixelStride = 4;
     Monitor CreateMonitor(int index, int id, int h, int w, int ox, int oy, const std::string &n, float scale);
+    Monitor CreateMonitor(int index, int id, int adapter, int h, int w, int ox, int oy, const std::string &n, float scale);
 
     Image Create(const ImageRect &imgrect, int pixelstride, int rowpadding, const unsigned char *data);
     // this function will copy data from the src into the dst. The only requirement is that src must not be larger than dst, but it can be smaller

--- a/include/ScreenCapture.h
+++ b/include/ScreenCapture.h
@@ -27,7 +27,7 @@ namespace Screen_Capture {
     struct Monitor {
         int Id = INT32_MAX;
         int Index = INT32_MAX;
-        int Adapter = -1;
+        int Adapter = INT32_MAX;
         int Height = 0;
         int Width = 0;
         // Offsets are the number of pixels that a monitor can be from the origin. For example, users can shuffle their

--- a/include/ScreenCapture.h
+++ b/include/ScreenCapture.h
@@ -27,6 +27,7 @@ namespace Screen_Capture {
     struct Monitor {
         int Id = INT32_MAX;
         int Index = INT32_MAX;
+        int Adapter = -1;
         int Height = 0;
         int Width = 0;
         // Offsets are the number of pixels that a monitor can be from the origin. For example, users can shuffle their
@@ -68,6 +69,7 @@ namespace Screen_Capture {
     SC_LITE_EXTERN int Index(const Monitor &mointor);
     // unique identifier
     SC_LITE_EXTERN int Id(const Monitor &mointor);
+    SC_LITE_EXTERN int Adapter(const Monitor &mointor);
     SC_LITE_EXTERN int OffsetX(const Monitor &mointor);
     SC_LITE_EXTERN int OffsetY(const Monitor &mointor);
     SC_LITE_EXTERN const char *Name(const Monitor &mointor);

--- a/include/windows/DXFrameProcessor.h
+++ b/include/windows/DXFrameProcessor.h
@@ -1,35 +1,32 @@
 #pragma once
 #include "SCCommon.h"
+#include <DXGI.h>
 #include <memory>
-
-#define NOMINMAX
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
-#include <d3d11.h>
-#include <dxgi1_2.h>
 #include <wrl.h>
 
-#pragma comment(lib,"dxgi.lib")
-#pragma comment(lib,"d3d11.lib")
+#include <d3d11.h>
+#include <dxgi1_2.h>
+
+#pragma comment(lib, "dxgi.lib")
+#pragma comment(lib, "d3d11.lib")
 
 namespace SL {
-    namespace Screen_Capture {
-        class DXFrameProcessor: public BaseFrameProcessor {
-            Microsoft::WRL::ComPtr<ID3D11Device> Device;
-            Microsoft::WRL::ComPtr<ID3D11DeviceContext> DeviceContext;
-            Microsoft::WRL::ComPtr<ID3D11Texture2D> StagingSurf;
+namespace Screen_Capture {
+    class DXFrameProcessor : public BaseFrameProcessor {
+        Microsoft::WRL::ComPtr<ID3D11Device> Device;
+        Microsoft::WRL::ComPtr<ID3D11DeviceContext> DeviceContext;
+        Microsoft::WRL::ComPtr<ID3D11Texture2D> StagingSurf;
 
-            Microsoft::WRL::ComPtr<IDXGIOutputDuplication> OutputDuplication;
-            DXGI_OUTPUT_DESC OutputDesc;
-            UINT Output;
-            std::vector<BYTE> MetaDataBuffer;
-            Monitor SelectedMonitor;
+        Microsoft::WRL::ComPtr<IDXGIOutputDuplication> OutputDuplication;
+        DXGI_OUTPUT_DESC OutputDesc;
+        UINT Output;
+        std::vector<BYTE> MetaDataBuffer;
+        Monitor SelectedMonitor;
 
-        public:
-            DUPL_RETURN Init(std::shared_ptr<Thread_Data> data, Monitor& monitor);
-            DUPL_RETURN ProcessFrame(const Monitor& currentmonitorinfo);
+      public:
+        DUPL_RETURN Init(std::shared_ptr<Thread_Data> data, Monitor &monitor);
+        DUPL_RETURN ProcessFrame(const Monitor &currentmonitorinfo);
+    };
 
-        };
-
-    }
-}
+} // namespace Screen_Capture
+} // namespace SL

--- a/src/SCCommon.cpp
+++ b/src/SCCommon.cpp
@@ -138,6 +138,13 @@ namespace Screen_Capture {
         return ret;
     }
 
+    Monitor CreateMonitor(int index, int id, int adapter, int h, int w, int ox, int oy, const std::string &n, float scaling)
+    {
+        Monitor ret = CreateMonitor(index, id, h, w, ox, oy, n, scaling);
+        ret.Adapter = adapter;
+        return ret;
+    }
+
     Image Create(const ImageRect &imgrect, int pixelstride, int rowpadding, const unsigned char *data)
     {
         Image ret;
@@ -149,6 +156,7 @@ namespace Screen_Capture {
     }
     int Index(const Monitor &mointor) { return mointor.Index; }
     int Id(const Monitor &mointor) { return mointor.Id; }
+    int Adapter(const Monitor &mointor) { return mointor.Adapter; }
     int OffsetX(const Monitor &mointor) { return mointor.OffsetX; }
     int OffsetY(const Monitor &mointor) { return mointor.OffsetY; }
     const char *Name(const Monitor &mointor) { return mointor.Name; }

--- a/src/windows/DXFrameProcessor.cpp
+++ b/src/windows/DXFrameProcessor.cpp
@@ -2,7 +2,6 @@
 #include <atomic>
 #include <iostream>
 #include <memory>
-#include <mutex>
 #include <string>
 
 #if (_MSC_VER >= 1700) && defined(_USING_V110_SDK71_)
@@ -140,6 +139,7 @@ namespace Screen_Capture {
     DUPL_RETURN Initialize(DUPLE_RESOURCES &r, ID3D11Device *device, const UINT adapter, const UINT output)
     {
         Microsoft::WRL::ComPtr<IDXGIFactory> pFactory;
+
         // Create a DXGIFactory object.
         HRESULT hr = CreateDXGIFactory(__uuidof(IDXGIFactory), (void **)pFactory.GetAddressOf());
         if (FAILED(hr)) {

--- a/src/windows/DXFrameProcessor.cpp
+++ b/src/windows/DXFrameProcessor.cpp
@@ -139,11 +139,9 @@ namespace Screen_Capture {
 
     DUPL_RETURN Initialize(DUPLE_RESOURCES &r, ID3D11Device *device, const UINT adapter, const UINT output)
     {
-        IDXGIAdapter * pAdapter;
-        IDXGIFactory* pFactory = NULL;
-
+        Microsoft::WRL::ComPtr<IDXGIFactory> pFactory;
         // Create a DXGIFactory object.
-        HRESULT hr = CreateDXGIFactory(__uuidof(IDXGIFactory), (void**)&pFactory);
+        HRESULT hr = CreateDXGIFactory(__uuidof(IDXGIFactory), (void **)pFactory.GetAddressOf());
         if (FAILED(hr)) {
             return ProcessFailure(nullptr, L"Failed to construct DXGIFactory", L"Error", hr);
         }

--- a/src/windows/GetMonitors.cpp
+++ b/src/windows/GetMonitors.cpp
@@ -1,17 +1,6 @@
 #include "SCCommon.h"
 #include "ScreenCapture.h"
-#define NOMINMAX
-#define WIN32_LEAN_AND_MEAN // Exclude rarely-used stuff from Windows headers
-#include <Windows.h>
-#include <d3d11.h>
-#include <dxgi1_2.h>
-#include <wrl.h>
-
-#include <codecvt>
-#include <locale>
-
-#pragma comment(lib, "dxgi.lib")
-#pragma comment(lib, "d3d11.lib")
+#include <DXGI.h>
 
 namespace SL {
 namespace Screen_Capture {

--- a/src/windows/GetMonitors.cpp
+++ b/src/windows/GetMonitors.cpp
@@ -3,50 +3,108 @@
 #define NOMINMAX
 #define WIN32_LEAN_AND_MEAN // Exclude rarely-used stuff from Windows headers
 #include <Windows.h>
+#include <d3d11.h>
+#include <dxgi1_2.h>
+#include <wrl.h>
+
+#include <locale>
+#include <codecvt>
+
+#pragma comment(lib,"dxgi.lib")
+#pragma comment(lib,"d3d11.lib")
 
 namespace SL {
 namespace Screen_Capture {
 
+    float scaleFromDpi(int xdpi)
+    {
+        switch (xdpi) {
+        case 96:
+            return 1.0f;
+            break;
+        case 120:
+            return 1.25f;
+            break;
+        case 144:
+            return 1.5f;
+            break;
+        case 192:
+            return 2.0f;
+            break;
+        }
+
+        return 1.0f;
+    }
+
     std::vector<Monitor> GetMonitors()
     {
         std::vector<Monitor> ret;
-        DISPLAY_DEVICEA dd;
-        ZeroMemory(&dd, sizeof(dd));
-        dd.cb = sizeof(dd);
-        for (auto i = 0; EnumDisplayDevicesA(NULL, i, &dd, 0); i++) {
-            // monitor must be attached to desktop and not a mirroring device
 
-            if (((dd.StateFlags & DISPLAY_DEVICE_ATTACHED_TO_DESKTOP) != 0 || (dd.StateFlags & DISPLAY_DEVICE_PRIMARY_DEVICE) != 0) &&
-                (dd.StateFlags & DISPLAY_DEVICE_MIRRORING_DRIVER) == 0) {
-                DEVMODEA devMode;
-                devMode.dmSize = sizeof(devMode);
-                EnumDisplaySettingsA(dd.DeviceName, ENUM_CURRENT_SETTINGS, &devMode);
-                std::string name = dd.DeviceName;
-                auto mon = CreateDCA(dd.DeviceName, NULL, NULL, NULL);
+        IDXGIAdapter * pAdapter;
+        std::vector <IDXGIAdapter*> vAdapters;
+        IDXGIFactory* pFactory = NULL;
+
+        // Create a DXGIFactory object.
+        if (FAILED(CreateDXGIFactory(__uuidof(IDXGIFactory), (void**)&pFactory)))
+        {
+            //Couldn't enumerate displays with DXGI, fall back to EnumDisplayDevices
+            DISPLAY_DEVICEA dd;
+            ZeroMemory(&dd, sizeof(dd));
+            dd.cb = sizeof(dd);
+            for (auto i = 0; EnumDisplayDevicesA(NULL, i, &dd, 0); i++) {
+                // monitor must be attached to desktop and not a mirroring device
+
+                if (((dd.StateFlags & DISPLAY_DEVICE_ATTACHED_TO_DESKTOP) != 0 || (dd.StateFlags & DISPLAY_DEVICE_PRIMARY_DEVICE) != 0) &&
+                    (dd.StateFlags & DISPLAY_DEVICE_MIRRORING_DRIVER) == 0) {
+                    DEVMODEA devMode;
+                    devMode.dmSize = sizeof(devMode);
+                    EnumDisplaySettingsA(dd.DeviceName, ENUM_CURRENT_SETTINGS, &devMode);
+                    std::string name = dd.DeviceName;
+                    auto mon = CreateDCA(dd.DeviceName, NULL, NULL, NULL);
+                    auto xdpi = GetDeviceCaps(mon, LOGPIXELSX);
+                    DeleteDC(mon);
+                    auto scale = scaleFromDpi(xdpi);
+                    
+                    ret.push_back(CreateMonitor(static_cast<int>(ret.size()), i, devMode.dmPelsHeight, devMode.dmPelsWidth, devMode.dmPosition.x,
+                        devMode.dmPosition.y, name, scale));
+                }
+            }
+            return ret;
+        }
+
+        for (UINT i = 0;
+            pFactory->EnumAdapters(i, &pAdapter) != DXGI_ERROR_NOT_FOUND;
+            ++i)
+        {
+            IDXGIOutput * pOutput;
+
+            for (UINT j = 0;
+                pAdapter->EnumOutputs(j, &pOutput) != DXGI_ERROR_NOT_FOUND;
+                ++j)
+            {
+                DXGI_OUTPUT_DESC desc;
+                pOutput->GetDesc(&desc);
+
+                std::wstring wname = desc.DeviceName;
+
+                int size_needed = WideCharToMultiByte(CP_UTF8, 0, &wname[0], (int)wname.size(), NULL, 0, NULL, NULL);
+                std::string name(size_needed, 0);
+                WideCharToMultiByte(CP_UTF8, 0, &wname[0], (int)wname.size(), &name[0], size_needed, NULL, NULL);
+
+                DEVMODEW devMode;
+                EnumDisplaySettingsW(desc.DeviceName, ENUM_CURRENT_SETTINGS, &devMode);
+
+                auto mon = CreateDCW(desc.DeviceName, NULL, NULL, NULL);
                 auto xdpi = GetDeviceCaps(mon, LOGPIXELSX);
                 DeleteDC(mon);
-                auto scale = 1.0f;
-                switch (xdpi) {
-                case 96:
-                    scale = 1.0f;
-                    break;
-                case 120:
-                    scale = 1.25f;
-                    break;
-                case 144:
-                    scale = 1.5f;
-                    break;
-                case 192:
-                    scale = 2.0f;
-                    break;
-                default:
-                    scale = 1.0f;
-                    break;
-                }
-                ret.push_back(CreateMonitor(static_cast<int>(ret.size()), i, devMode.dmPelsHeight, devMode.dmPelsWidth, devMode.dmPosition.x,
-                                            devMode.dmPosition.y, name, scale));
+                auto scale = scaleFromDpi(xdpi);
+
+                bool flipSides = desc.Rotation == DXGI_MODE_ROTATION_ROTATE90 || desc.Rotation == DXGI_MODE_ROTATION_ROTATE270;
+                ret.push_back(CreateMonitor(static_cast<int>(ret.size()), j, i, flipSides ? devMode.dmPelsWidth : devMode.dmPelsHeight, flipSides ? devMode.dmPelsHeight : devMode.dmPelsWidth,
+                    devMode.dmPosition.x, devMode.dmPosition.y, name, scale));
             }
         }
+
         return ret;
     }
 } // namespace Screen_Capture

--- a/src/windows/ThreadRunner.cpp
+++ b/src/windows/ThreadRunner.cpp
@@ -67,11 +67,13 @@ namespace SL {
             std::cout << "Starting to Capture on Monitor " << Name(monitor) << std::endl;
             std::cout << "Trying DirectX Desktop Duplication " << std::endl;
 #endif
-            if (!TryCaptureMonitor<DXFrameProcessor>(data, monitor)) {//if DX is not supported, fallback to GDI capture
-#if defined _DEBUG || !defined NDEBUG
-                std::cout << "DirectX Desktop Duplication not supprted, falling back to GDI Capturing . . ." << std::endl;
-#endif
+            if (monitor.Adapter == -1)
+            {
                 TryCaptureMonitor<GDIFrameProcessor>(data, monitor);
+            }
+            else
+            {
+                TryCaptureMonitor<DXFrameProcessor>(data, monitor);
             }
         }
 


### PR DESCRIPTION
Fixes two DXGI issues
1. incorrect assumption that capture will only happen on the first DXGI
adapter, and that the order of outputs from DXGI matches the order of
outputs that it gets from `EnumDisplayDevices`
2. chokes on monitors rotated 90 or 270 degrees

Addresses #46 - DXGI issues: EnumDisplayDevices mismatch, and rotated monitors