### PR TITLE
fix for freezing on getting current window text

### DIFF
--- a/src/windows/GetWindows.cpp
+++ b/src/windows/GetWindows.cpp
@@ -15,7 +15,14 @@ namespace Screen_Capture {
     {
         Window w;
         char buffer[sizeof(w.Name)];
-        GetWindowTextA(hwnd, buffer, sizeof(buffer));
+        { // exclude windows for current process
+			DWORD pid;
+			GetWindowThreadProcessId(hwnd, &pid);
+			if (pid != GetProcessId(GetCurrentProcess()))
+			{
+				GetWindowTextA(hwnd, buffer, sizeof(buffer));
+			}
+		}
         srch *s = (srch *)lParam;
         std::string name = buffer;
         w.Handle = reinterpret_cast<size_t>(hwnd);


### PR DESCRIPTION
On Windows GetWindowTextA is simply SendMessage that is getting stuck on waiting for current process window to respond which will never happen obviously if the window is not created yet or is frozen by this code. The caller should know better own window title text so exclude own window titles in the enumeration process.