### PR TITLE
Fixed compile issue with gcc 6

### DIFF
--- a/include/internal/ThreadManager.h
+++ b/include/internal/ThreadManager.h
@@ -38,7 +38,11 @@ namespace Screen_Capture {
             // get a copy of the shared_ptr in a safe way
 
             std::shared_ptr<Timer> timer;
+            #if defined(__GNUC__) && __GNUC__ > 6
             if constexpr(sizeof...(args) == 1) {
+            #else
+            if (sizeof...(args) == 1) {
+            #endif
                 timer = std::atomic_load(&data->WindowCaptureData.MouseTimer);
             }
             else {


### PR DESCRIPTION
'if constexpr' isnt supported below gcc7(even with -std=gnu++17), so here's a quick fix to handle it. In debian stretch, gcc7 isn't stable.  I am not sure if clang would need a similar thing, but I figured id make the pull request to bring it to your attention.

I am not sure if cmake would handle this(it probably doesn't) because I use a separate makefile to build