### PR TITLE
only build example if option is ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,4 +142,6 @@ install (FILES
 	DESTINATION include
 )
 enable_testing() 
-add_subdirectory(Example) 
+if (${BUILD_EXAMPLE})
+  add_subdirectory(Example) 
+endif()


### PR DESCRIPTION
CMakeLists.txt file has an option to build an example (`BUILD_EXAMPLE`) but it builds the example even with BUILD_EXAMPLE set to `OFF`.

Fixed it.