### PR TITLE
Use atomic shared ptr instead of deprecated overload

### DIFF
--- a/include/internal/SCCommon.h
+++ b/include/internal/SCCommon.h
@@ -7,10 +7,10 @@
 namespace SL {
 namespace Screen_Capture {
     template <typename F, typename M, typename W> struct CaptureData {
-        std::shared_ptr<Timer> FrameTimer;
+        std::atomic<std::shared_ptr<Timer> > FrameTimer;
         F OnNewFrame;
         F OnFrameChanged;
-        std::shared_ptr<Timer> MouseTimer;
+        std::atomic<std::shared_ptr<Timer> > MouseTimer;
         M OnMouseChanged;
         W getThingsToWatch;
     };

--- a/include/internal/ThreadManager.h
+++ b/include/internal/ThreadManager.h
@@ -99,7 +99,7 @@ namespace Screen_Capture {
             // get a copy of the shared_ptr in a safe way
             
             frameprocessor.Resume();
-            auto timer = std::atomic_load(&data->ScreenCaptureData.FrameTimer);
+            auto timer = data->ScreenCaptureData.FrameTimer.load();
             timer->start();
             auto monitors = GetMonitors();
             if (isMonitorInsideBounds(monitors, monitor) && !HasMonitorsChanged(startmonitors, monitors)) {
@@ -145,7 +145,7 @@ namespace Screen_Capture {
         }
         while (!data->CommonData_.TerminateThreadsEvent) {
             // get a copy of the shared_ptr in a safe way
-            auto timer = std::atomic_load(&data->WindowCaptureData.FrameTimer);
+            auto timer = data->WindowCaptureData.FrameTimer.load();
             timer->start();
             ret = frameprocessor.ProcessFrame(wnd);
             if (ret != DUPL_RETURN_SUCCESS) {

--- a/src_cpp/ScreenCapture.cpp
+++ b/src_cpp/ScreenCapture.cpp
@@ -137,13 +137,13 @@ namespace Screen_Capture {
         }
         virtual void setFrameChangeInterval(const std::shared_ptr<Timer> &timer) override
         {
-            std::atomic_store(&Thread_Data_->ScreenCaptureData.FrameTimer, timer);
-            std::atomic_store(&Thread_Data_->WindowCaptureData.FrameTimer, timer);
+            Thread_Data_->ScreenCaptureData.FrameTimer.store(timer);
+            Thread_Data_->WindowCaptureData.FrameTimer.store(timer);
         }
         virtual void setMouseChangeInterval(const std::shared_ptr<Timer> &timer) override
         {
-            std::atomic_store(&Thread_Data_->ScreenCaptureData.MouseTimer, timer);
-            std::atomic_store(&Thread_Data_->WindowCaptureData.MouseTimer, timer);
+            Thread_Data_->ScreenCaptureData.MouseTimer.store(timer);
+            Thread_Data_->WindowCaptureData.MouseTimer.store(timer);
         }
         virtual void pause() override { Thread_Data_->CommonData_.Paused = true; }
         virtual bool isPaused() const override { return Thread_Data_->CommonData_.Paused; }


### PR DESCRIPTION
This removed the msvc warnings when compiling with language set to C++20 or newer.