### PR TITLE
docs: Fix a few typos

### DIFF
--- a/Example_CPP/lodepng.h
+++ b/Example_CPP/lodepng.h
@@ -1422,7 +1422,7 @@ The LodePNGInfo struct contains fields with the unknown chunk in it. It has 3
 buffers (each with size) to contain 3 types of unknown chunks:
 the ones that come before the PLTE chunk, the ones that come between the PLTE
 and the IDAT chunks, and the ones that come after the IDAT chunks.
-It's necessary to make the distionction between these 3 cases because the PNG
+It's necessary to make the distinction between these 3 cases because the PNG
 standard forces to keep the ordering of unknown chunks compared to the critical
 chunks, but does not force any other ordering rules.
 

--- a/Example_OpenGL/glfw/examples/splitview.c
+++ b/Example_OpenGL/glfw/examples/splitview.c
@@ -2,7 +2,7 @@
 // This is an example program for the GLFW library
 //
 // The program uses a "split window" view, rendering four views of the
-// same scene in one window (e.g. uesful for 3D modelling software). This
+// same scene in one window (e.g. useful for 3D modelling software). This
 // demo uses scissors to separate the four different rendering areas from
 // each other.
 //

--- a/Example_OpenGL/glfw/src/win32_platform.h
+++ b/Example_OpenGL/glfw/src/win32_platform.h
@@ -326,7 +326,7 @@ typedef struct _GLFWwindowWin32
 
     // The last received cursor position, regardless of source
     int                 lastCursorPosX, lastCursorPosY;
-    // The last recevied high surrogate when decoding pairs of UTF-16 messages
+    // The last received high surrogate when decoding pairs of UTF-16 messages
     WCHAR               highSurrogate;
 
 } _GLFWwindowWin32;


### PR DESCRIPTION
There are small typos in:
- Example_CPP/lodepng.h
- Example_OpenGL/glfw/examples/splitview.c
- Example_OpenGL/glfw/src/win32_platform.h

Fixes:
- Should read `useful` rather than `uesful`.
- Should read `received` rather than `recevied`.
- Should read `distinction` rather than `distionction`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md