### PR TITLE
Change cmake install dir so that homebrew can auto-detect it 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ configure_file(modules/${TARGET_NAME}Config.cmake.in ${TARGET_NAME}Config.cmake 
 #install(EXPORT ${TARGET_NAME}-config FILE ${TARGET_NAME}-config.cmake DESTINATION lib/cmake/screen_capture_lite)
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${TARGET_NAME}Config.cmake
-  DESTINATION lib${LIB_SUFFIX}/cmake)
+  DESTINATION lib${LIB_SUFFIX}/cmake/${TARGET_NAME})
 
  
 install (FILES 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ configure_file(modules/${TARGET_NAME}Config.cmake.in ${TARGET_NAME}Config.cmake 
 #install(EXPORT ${TARGET_NAME}-config FILE ${TARGET_NAME}-config.cmake DESTINATION lib/cmake/screen_capture_lite)
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${TARGET_NAME}Config.cmake
-  DESTINATION lib${LIB_SUFFIX}/cmake/screen_capture_lite)
+  DESTINATION lib${LIB_SUFFIX}/cmake)
 
  
 install (FILES 


### PR DESCRIPTION
Hello,
I created a local homebrew repository to simplify the install of screen_capture_lite in one of my projects on MacOS.
You can see the homebrew formula here if you are interested : [screen_capture_lite_shared.rb](https://github.com/RandomPrototypes/homebrew-tap-dev/blob/main/screen_capture_lite_shared.rb)
The library can be install by the command `brew install RandomPrototypes/tap-dev/screen_capture_lite_shared`

To make this formula work, I had to do one small modification in the CMakeLists.txt
By changing the cmake folder into `lib/cmake/screen_capture_lite_shared/` or `lib/cmake/screen_capture_lite_static/` instead of `lib/cmake/screen_capture_lite/`, it allows to auto detect the library when calling find_package(screen_capture_lite_shared REQUIRED) without having to specify the install folder.