### PR TITLE
Ported screen_capture_lite to MinGW-w64 and Clang on Windows.

### DIFF
--- a/include/ScreenCapture.h
+++ b/include/ScreenCapture.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(WINDOWS) || defined(WIN32)
+#if defined(WINDOWS) || defined(WIN32) || defined(__MINGW32__)
 #if defined(SC_LITE_DLL)
 #define SC_LITE_EXTERN __declspec(dllexport)
 #else

--- a/include/ScreenCapture_C_API.h
+++ b/include/ScreenCapture_C_API.h
@@ -5,7 +5,7 @@
 #ifndef SCREEN_CAPTURE_LITE_BUILD_SCREENCAPTURE_C_API_H
 #define SCREEN_CAPTURE_LITE_BUILD_SCREENCAPTURE_C_API_H
 
-#if defined(WINDOWS) || defined(WIN32)
+#if defined(WINDOWS) || defined(WIN32) || defined(__MINGW32__)
 #if defined(SC_LITE_DLL) && defined(__cplusplus)
 #define SC_LITE_C_EXTERN extern "C" __declspec(dllexport)
 #else

--- a/include/windows/DXFrameProcessor.h
+++ b/include/windows/DXFrameProcessor.h
@@ -7,9 +7,6 @@
 #include <d3d11.h>
 #include <dxgi1_2.h>
 
-#pragma comment(lib, "dxgi.lib")
-#pragma comment(lib, "d3d11.lib")
-
 namespace SL {
     namespace Screen_Capture {
         class DXFrameProcessor : public BaseFrameProcessor {

--- a/src_cpp/CMakeLists.txt
+++ b/src_cpp/CMakeLists.txt
@@ -17,6 +17,7 @@ if(WIN32)
        ../include/windows 
     )
 	add_definitions(-DNOMINMAX)
+	link_libraries(dxgi.lib d3d11.lib)
 elseif(APPLE)
 
     set(SCREEN_CAPTURE_PLATFORM_SRC
@@ -80,12 +81,13 @@ set(libsrc
 if(NOT ${BUILD_SHARED_LIBS})
     message("Building STATIC Library")
     add_library(${PROJECT_NAME}_static STATIC ${libsrc})
+		target_link_libraries(${PROJECT_NAME}_static Dwmapi)
 else()
   message("Building SHARED Library")
   
     add_library(${PROJECT_NAME}_shared SHARED ${libsrc} ../include/ScreenCapture_C_API.h)
 
-	set_target_properties(${PROJECT_NAME}_shared PROPERTIES DEFINE_SYMBOL SC_LITE_DLL)
+	add_definitions(-DSC_LITE_DLL)
 	 if(WIN32) 
 		target_link_libraries(${PROJECT_NAME}_shared Dwmapi)
 		if (!MINGW)

--- a/src_cpp/windows/GDIFrameProcessor.cpp
+++ b/src_cpp/windows/GDIFrameProcessor.cpp
@@ -1,6 +1,10 @@
 #include "GDIFrameProcessor.h"
 #include <Dwmapi.h>
 
+#ifndef PW_RENDERFULLCONTENT
+    #define PW_RENDERFULLCONTENT 2
+#endif
+
 namespace SL {
 namespace Screen_Capture {
 


### PR DESCRIPTION
See https://github.com/smasherprog/screen_capture_lite/issues/168.

Tested compilers :
- MSVC 14.43.34808
- MinGW-w64 11.0
- MSYS2 Clang 19.1.7